### PR TITLE
Default output locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ AZURE_AVATAR_API_VERSION=2024-04-15-preview
 1. Install dependencies `pip3 install -r requirements.txt`
 
 ## Create a transcription from a video
-1. Run script `python transcription.py --help` for arguments, options and usage
+1. Run script `python transcription.py -i <full path to input video file>` or `python transcription.py --help` for arguments, options and usage
 
 ## Create AI speech audio from transcription
 1. Run script `python tts.py --help` for arguments, options and usage

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ AZURE_AVATAR_API_VERSION=2024-04-15-preview
 1. Run script `python transcription.py -i <full path to input video file>` or `python transcription.py --help` for arguments, options and usage
 
 ## Create AI speech audio from transcription
-1. Run script `python tts.py --help` for arguments, options and usage
+1. Run script `python tts.py -i <full path to input transcription file>` or `python tts.py --help` for arguments, options and usage
 
 ## Create AI avatar video from transcription
 1. Run script `python avatar.py --help` for arguments, options and usage

--- a/avatar.py
+++ b/avatar.py
@@ -73,12 +73,12 @@ def get_synthesis(job_id):
             download_response = requests.get(response.json()["outputs"]["result"], stream=True)
             if download_response.status_code == 200:
                 # Open a local file with write-binary mode
-                with open(args.outputvideofilename, 'wb') as file:
+                with open(output_video_path, 'wb') as file:
                     # Iterate over the response data in chunks
                     for chunk in download_response.iter_content(chunk_size=8192):
                         # Write each chunk to the file
                         file.write(chunk)
-                print(f"File downloaded successfully: {args.outputvideofilename}")
+                print(f"File downloaded successfully: {output_video_path}")
             else:
                 print(f"Failed to download file. Status code: {response.status_code}")
         elif response.json()['status'] == 'Failed':
@@ -96,17 +96,9 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
-    '-it', '--inputtranscriptionfilename',
+    '-i', '--inputtranscriptionfilename',
     type=str, 
     help='Required. The path of the input transcription file (TXT).'
-)
-
-parser.add_argument(
-    '-ov', '--outputvideofilename',
-    nargs='?', 
-    default='output/avatar/output_avatar.mp4', 
-    type=str, 
-    help='The path of the output video file (MP4). Defaults to "output/avatar/output_avatar.mp4"'
 )
 
 parser.add_argument(
@@ -144,6 +136,9 @@ print("Starting")
 
 # Load the .env file
 load_dotenv()
+
+# Set paths
+output_video_path = os.path.splitext(args.inputtranscriptionfilename)[0] + "_avatar.mp4"
 
 # Get env vars
 SPEECH_REGION = os.getenv('AZURE_SPEECH_REGION')

--- a/avatar.py
+++ b/avatar.py
@@ -158,4 +158,4 @@ if submit_synthesis(job_id):
             print(f'Batch avatar synthesis job is still running, status [{status}]')
             time.sleep(10)
 
-print("Done")
+print("Avatar.py is complete")

--- a/output/ReadMe.md
+++ b/output/ReadMe.md
@@ -1,1 +1,0 @@
-You will find the output from both scripts here.

--- a/output/avatar/ReadMe.md
+++ b/output/avatar/ReadMe.md
@@ -1,1 +1,0 @@
-You will find the output from avatar.py here.

--- a/output/transcription/ReadMe.md
+++ b/output/transcription/ReadMe.md
@@ -1,1 +1,0 @@
-You will find the output from transcription.py here.

--- a/output/tts/ReadMe.md
+++ b/output/tts/ReadMe.md
@@ -1,1 +1,0 @@
-You will find the output from tts.py here.

--- a/transcription.py
+++ b/transcription.py
@@ -10,25 +10,9 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
-    '-iv', '--inputvideofilename',
+    '-i', '--inputvideofilename',
     type=str, 
-    help='Required. The path and file name of the input video.'
-)
-
-parser.add_argument(
-    '-oa', '--outputaudiofilename',
-    nargs='?', 
-    default='output/transcription/output_original_audio.mp3', 
-    type=str, 
-    help='The path of the output audio file (MP3). Defaults to output/transcription/output_original_audio.mp3'
-)
-
-parser.add_argument(
-    '-ot', '--outputtranscriptionfilename',
-    nargs='?', 
-    default='output/transcription/output_transcription.txt', 
-    type=str, 
-    help='The path of the output transcription file (TXT). Defaults to output/transcription/output_transcription.txt'
+    help='Required. The absolute path, including file name to the input video.'
 )
 
 # Parse the arguments
@@ -43,7 +27,7 @@ print("Starting")
 
 # Set paths
 output_audio_path = os.path.splitext(args.inputvideofilename)[0] + "_audio.mp3"
-
+output_transcription_path = os.path.splitext(args.inputvideofilename)[0] + "_transcription.txt"
 
 # Load the .env file
 load_dotenv()
@@ -66,8 +50,7 @@ transcription_result = transcription_client.audio.transcriptions.create(
     model=os.getenv("AZURE_OPENAI_WHISPER_DEPLOYMENT"),
     language="en")
 
-with open(args.outputtranscriptionfilename, "w") as file:
+with open(output_transcription_path, "w") as file:
     file.write(transcription_result.text)
 
-print("3. Written transcription to " +args.outputtranscriptionfilename)
-print("Done")
+print("Transcription.py is complete")

--- a/transcription.py
+++ b/transcription.py
@@ -39,8 +39,11 @@ if len(sys.argv)==1:
     parser.print_help(sys.stderr)
     sys.exit(1)
 
-
 print("Starting")
+
+# Set paths
+output_audio_path = os.path.splitext(args.inputvideofilename)[0] + "_audio.mp3"
+
 
 # Load the .env file
 load_dotenv()
@@ -49,7 +52,7 @@ load_dotenv()
 print("1. Getting the audio from the video " +args.inputvideofilename)
 video = VideoFileClip(args.inputvideofilename)
 audio = video.audio
-audio.write_audiofile(args.outputaudiofilename)
+audio.write_audiofile(output_audio_path)
 
 # Get the audio as a transcript via OpenAI
 print("2. Transcribing the audio")
@@ -59,7 +62,7 @@ transcription_client = AzureOpenAI(
     azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
 )
 transcription_result = transcription_client.audio.transcriptions.create(
-    file=open("./"+args.outputaudiofilename, "rb"),           
+    file=open(output_audio_path, "rb"),           
     model=os.getenv("AZURE_OPENAI_WHISPER_DEPLOYMENT"),
     language="en")
 

--- a/tts.py
+++ b/tts.py
@@ -114,7 +114,7 @@ if args.voice in open_ai_voices:
 else:
     azurespeech()
 
-print("Done")
+print("Tts.py is complete")
 
 
 

--- a/tts.py
+++ b/tts.py
@@ -25,9 +25,9 @@ def openai():
 
     if tts_response.status_code == 200:
         # Save the binary content to a file
-        with open(args.outputaudiofilename, 'wb') as file:
+        with open(output_audio_path, 'wb') as file:
             file.write(tts_response.content)
-        print("2. TTS output file saved successfully as " +args.outputaudiofilename)
+        print("2. TTS output file saved successfully as " +output_audio_path)
     else:
         print(f"Failed to retrieve content. Status code: {tts_response.status_code}")
         print(f"Response content: {tts_response.content}")
@@ -42,7 +42,7 @@ def azurespeech():
     speech_service_region = os.getenv("AZURE_SPEECH_REGION")
     speech_config = speechsdk.SpeechConfig(subscription=speech_service_key, region=speech_service_region)
     speech_config.speech_synthesis_voice_name = args.voice
-    audio_output = speechsdk.audio.AudioOutputConfig(filename=args.outputaudiofilename)
+    audio_output = speechsdk.audio.AudioOutputConfig(filename=output_audio_path)
     synthesizer = speechsdk.SpeechSynthesizer(speech_config=speech_config, audio_config=audio_output)
 
     # Perform the speech synthesis
@@ -50,7 +50,7 @@ def azurespeech():
 
     # Check result status
     if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:
-        print("2. TTS output file saved successfully as " +args.outputaudiofilename)
+        print("2. TTS output file saved successfully as " +output_audio_path)
     elif result.reason == speechsdk.ResultReason.Canceled:
         cancellation_details = result.cancellation_details
         print(f"Speech synthesis canceled: {cancellation_details.reason}")
@@ -62,7 +62,7 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
-    '-it', '--inputtranscriptionfilename',
+    '-i', '--inputtranscriptionfilename',
     type=str, 
     required=True,
     help='Required. The path of the input transcription file (TXT).'
@@ -77,15 +77,6 @@ parser.add_argument(
     help='Which voice to use. Can be one of the 6 OpenAI voices (alloy, echo, fable, onyx, nova, shimmer) or one of the many Azure Speech Service voices such as `en-GB-BellaNeural`. Defaults to alloy'
 )
 
-parser.add_argument(
-    '-oa', '--outputaudiofilename',
-    nargs='?', 
-    default='', 
-    type=str, 
-    help='The path of the output audio file (MP3). Defaults to "output/tts/<name of input file>.mp3"'
-)
-
-
 # Parse the arguments
 args = parser.parse_args()
 
@@ -94,10 +85,8 @@ if len(sys.argv)==1:
     parser.print_help(sys.stderr)
     sys.exit(1)
 
-# Set the output file name based on input file name if blank
-if args.outputaudiofilename is None or args.outputaudiofilename == "":
-    inputfilename = os.path.basename(args.inputtranscriptionfilename)
-    args.outputaudiofilename = f"output/tts/{inputfilename}.mp3"
+# Set paths
+output_audio_path = os.path.splitext(args.inputtranscriptionfilename)[0] + "_aiaudio.mp3"
 
 print("Starting")
 


### PR DESCRIPTION
Remove params for output files and default to the same folder as the input file for ease of use. Also change arguments to use single chars, mostly `-i` rather than `-iv`